### PR TITLE
handle required correctly

### DIFF
--- a/embed.go
+++ b/embed.go
@@ -43,6 +43,7 @@ func embedDefinition(def *v1beta1.JSONSchemaProps, refs map[string]v1beta1.JSONS
 			log.Panicf("can't find the definition of %q", refName)
 		}
 		def.Properties = ref.Properties
+		def.Required = ref.Required
 		def.Type = ref.Type
 		def.Ref = nil
 	}

--- a/flattener.go
+++ b/flattener.go
@@ -32,6 +32,7 @@ func recursiveFlatten(schema *v1beta1.JSONSchemaProps, definition *v1beta1.JSONS
 
 	aggregatedDef := &v1beta1.JSONSchemaProps{
 		Properties: definition.Properties,
+		Required:   definition.Required,
 	}
 	for _, allOfDef := range definition.AllOf {
 		var newDef *v1beta1.JSONSchemaProps
@@ -67,6 +68,8 @@ func mergeDefinitions(lhsDef *v1beta1.JSONSchemaProps, rhsDef *v1beta1.JSONSchem
 	}
 	// 2. Transfer the description
 	lhsDef.Description = rhsDef.Description
+	// 3. Merge required fields
+	lhsDef.Required = append(lhsDef.Required, rhsDef.Required...)
 }
 
 // Flattens the schema by inlining 'allOf' tags.

--- a/main.go
+++ b/main.go
@@ -159,7 +159,7 @@ func structTypeToSchema(structType *ast.StructType, importPaths map[string]strin
 			continue
 		}
 
-		if option == "required" {
+		if option != "inline" && option != "omitempty" {
 			def.Required = append(def.Required, yamlName)
 		}
 


### PR DESCRIPTION
If I have the following type definitions
```
type Foo struct {
	FooA string `json:"fooA,omitempty"`
	FooB []string `json:"fooB"`
}

type Bar struct {
	Foo `json:",inline"`
	BarA float32 `json:"barA"`
	BarB float32 `json:"barB,omitempty"`
}
```

Bar should have the following required fields
```
- fooB
- barA
```
