### PR TITLE
type:object should not be missing

### DIFF
--- a/flattener.go
+++ b/flattener.go
@@ -33,6 +33,7 @@ func recursiveFlatten(schema *v1beta1.JSONSchemaProps, definition *v1beta1.JSONS
 	aggregatedDef := &v1beta1.JSONSchemaProps{
 		Properties: definition.Properties,
 		Required:   definition.Required,
+		Type:       definition.Type,
 	}
 	for _, allOfDef := range definition.AllOf {
 		var newDef *v1beta1.JSONSchemaProps

--- a/main.go
+++ b/main.go
@@ -211,7 +211,9 @@ func (f *file) mapTypeToSchema(mapType *ast.MapType, doc string, comments []*ast
 
 // structTypeToSchema converts ast.StructType to JSONSchemaProps by examining each field in the struct.
 func (f *file) structTypeToSchema(structType *ast.StructType, comments []*ast.CommentGroup) (*v1beta1.JSONSchemaProps, []TypeReference) {
-	def := &v1beta1.JSONSchemaProps{}
+	def := &v1beta1.JSONSchemaProps{
+		Type: "object",
+	}
 	externalTypeRefs := []TypeReference{}
 	for _, field := range structType.Fields.List {
 		yamlName, option := extractFromTag(field.Tag)


### PR DESCRIPTION
fixed an issue that `type:object` is missing in some cases, e.g. having inlined fields.
